### PR TITLE
chore: 댓글과 대댓글에 날짜 필드 추가 및 기본값 설정

### DIFF
--- a/src/model/answers.model.ts
+++ b/src/model/answers.model.ts
@@ -3,6 +3,8 @@ import { Schema, model, Types } from "mongoose";
 interface IAnswersArray {
   member_id: Types.ObjectId;
   contents: string;
+  created_at: Date | number;
+  deleted_at?: Date;
 }
 interface IAnswers {
   comment_id: Types.ObjectId;
@@ -12,6 +14,8 @@ interface IAnswers {
 const answersArraySchema = new Schema<IAnswersArray>({
   member_id: { type: Schema.Types.ObjectId, ref: "users", required: true },
   contents: { type: String, default: "" },
+  created_at: { type: Date, default: Date.now, required: true },
+  deleted_at: { type: Date },
 });
 
 const schema = new Schema<IAnswers>({

--- a/src/model/answers.model.ts
+++ b/src/model/answers.model.ts
@@ -14,7 +14,7 @@ interface IAnswers {
 const answersArraySchema = new Schema<IAnswersArray>({
   member_id: { type: Schema.Types.ObjectId, ref: "users", required: true },
   contents: { type: String, default: "" },
-  created_at: { type: Date, default: Date.now, required: true },
+  created_at: { type: Date, default: Date.now },
   deleted_at: { type: Date },
 });
 

--- a/src/model/answers.model.ts
+++ b/src/model/answers.model.ts
@@ -3,7 +3,7 @@ import { Schema, model, Types } from "mongoose";
 interface IAnswersArray {
   member_id: Types.ObjectId;
   contents: string;
-  created_at: Date | number;
+  created_at: Date;
   deleted_at?: Date;
 }
 interface IAnswers {
@@ -11,12 +11,14 @@ interface IAnswers {
   answers_array: IAnswersArray[];
 }
 
-const answersArraySchema = new Schema<IAnswersArray>({
-  member_id: { type: Schema.Types.ObjectId, ref: "users", required: true },
-  contents: { type: String, default: "" },
-  created_at: { type: Date, default: Date.now },
-  deleted_at: { type: Date },
-});
+const answersArraySchema = new Schema<IAnswersArray>(
+  {
+    member_id: { type: Schema.Types.ObjectId, ref: "users", required: true },
+    contents: { type: String, default: "" },
+    deleted_at: { type: Date },
+  },
+  { timestamps: { createdAt: "created_at" } }
+);
 
 const schema = new Schema<IAnswers>({
   comment_id: { type: Schema.Types.ObjectId, ref: "comments", required: true },

--- a/src/model/boards.model.ts
+++ b/src/model/boards.model.ts
@@ -27,7 +27,7 @@ const schema = new Schema<IBoard>({
   contents: { type: String, required: true },
   category: { type: String, required: true },
   view_cnt: { type: [viewCntSchema], default: [] },
-  created_at: { type: Date, default: Date.now, required: true },
+  created_at: { type: Date, default: Date.now },
   updated_at: { type: Date, default: Date.now },
   deleted_at: { type: Date },
 });

--- a/src/model/boards.model.ts
+++ b/src/model/boards.model.ts
@@ -2,35 +2,35 @@ import { Schema, model, Types } from "mongoose";
 
 interface IViewCnt {
   member_id: Types.ObjectId;
-  view_date: Date | number;
+  view_date: Date;
 }
 interface IBoard {
   title: string;
   contents: string;
   category: string;
   view_cnt: IViewCnt[];
-  created_at: Date | number;
-  updated_at?: Date | number;
-  deleted_at?: Date;
+  created_at: Date;
+  updated_at?: Date;
+  deleted_at?: Date | null;
 }
 
 const viewCntSchema = new Schema<IViewCnt>(
   {
     member_id: { type: Schema.Types.ObjectId, ref: "users", required: true },
-    view_date: { type: Date, default: Date.now, required: true },
   },
-  { _id: false }
+  { _id: false, timestamps: { createdAt: "view_date" } }
 );
 
-const schema = new Schema<IBoard>({
-  title: { type: String, required: true },
-  contents: { type: String, required: true },
-  category: { type: String, required: true },
-  view_cnt: { type: [viewCntSchema], default: [] },
-  created_at: { type: Date, default: Date.now },
-  updated_at: { type: Date, default: Date.now },
-  deleted_at: { type: Date },
-});
+const schema = new Schema<IBoard>(
+  {
+    title: { type: String, required: true },
+    contents: { type: String, required: true },
+    category: { type: String, required: true },
+    view_cnt: { type: [viewCntSchema], default: [] },
+    deleted_at: { type: Date },
+  },
+  { timestamps: { createdAt: "created_at", updatedAt: "updated_at" } }
+);
 
 const BoardModel = model<IBoard>("boards", schema);
 

--- a/src/model/boards.model.ts
+++ b/src/model/boards.model.ts
@@ -2,22 +2,22 @@ import { Schema, model, Types } from "mongoose";
 
 interface IViewCnt {
   member_id: Types.ObjectId;
-  view_date: Date;
+  view_date: Date | number;
 }
 interface IBoard {
   title: string;
   contents: string;
   category: string;
   view_cnt: IViewCnt[];
-  created_at: Date;
-  updated_at?: Date;
+  created_at: Date | number;
+  updated_at?: Date | number;
   deleted_at?: Date;
 }
 
 const viewCntSchema = new Schema<IViewCnt>(
   {
     member_id: { type: Schema.Types.ObjectId, ref: "users", required: true },
-    view_date: { type: Date, required: true },
+    view_date: { type: Date, default: Date.now, required: true },
   },
   { _id: false }
 );
@@ -27,8 +27,8 @@ const schema = new Schema<IBoard>({
   contents: { type: String, required: true },
   category: { type: String, required: true },
   view_cnt: { type: [viewCntSchema], default: [] },
-  created_at: { type: Date, required: true },
-  updated_at: { type: Date },
+  created_at: { type: Date, default: Date.now, required: true },
+  updated_at: { type: Date, default: Date.now },
   deleted_at: { type: Date },
 });
 

--- a/src/model/comments.model.ts
+++ b/src/model/comments.model.ts
@@ -3,20 +3,22 @@ import { Schema, model, Types } from "mongoose";
 interface ICommentsArray {
   member_id: Types.ObjectId;
   contents: string;
-  created_at: Date | number;
-  deleted_at?: Date;
+  created_at: Date;
+  deleted_at?: Date | null;
 }
 interface IComments {
   board_id: Types.ObjectId;
   comments_array: ICommentsArray[];
 }
 
-const commentsArraySchema = new Schema<ICommentsArray>({
-  member_id: { type: Schema.Types.ObjectId, ref: "users", required: true },
-  contents: { type: String, default: "" },
-  created_at: { type: Date, default: Date.now },
-  deleted_at: { type: Date },
-});
+const commentsArraySchema = new Schema<ICommentsArray>(
+  {
+    member_id: { type: Schema.Types.ObjectId, ref: "users", required: true },
+    contents: { type: String, default: "" },
+    deleted_at: { type: Date, default: null },
+  },
+  { timestamps: { createdAt: "created_at" } }
+);
 
 const schema = new Schema<IComments>({
   board_id: { type: Schema.Types.ObjectId, ref: "boards", required: true },

--- a/src/model/comments.model.ts
+++ b/src/model/comments.model.ts
@@ -3,6 +3,8 @@ import { Schema, model, Types } from "mongoose";
 interface ICommentsArray {
   member_id: Types.ObjectId;
   contents: string;
+  created_at: Date | number;
+  deleted_at?: Date;
 }
 interface IComments {
   board_id: Types.ObjectId;
@@ -12,6 +14,8 @@ interface IComments {
 const commentsArraySchema = new Schema<ICommentsArray>({
   member_id: { type: Schema.Types.ObjectId, ref: "users", required: true },
   contents: { type: String, default: "" },
+  created_at: { type: Date, default: Date.now, required: true },
+  deleted_at: { type: Date },
 });
 
 const schema = new Schema<IComments>({

--- a/src/model/comments.model.ts
+++ b/src/model/comments.model.ts
@@ -14,7 +14,7 @@ interface IComments {
 const commentsArraySchema = new Schema<ICommentsArray>({
   member_id: { type: Schema.Types.ObjectId, ref: "users", required: true },
   contents: { type: String, default: "" },
-  created_at: { type: Date, default: Date.now, required: true },
+  created_at: { type: Date, default: Date.now },
   deleted_at: { type: Date },
 });
 

--- a/src/model/users.model.ts
+++ b/src/model/users.model.ts
@@ -4,8 +4,8 @@ interface IUser {
   email: string;
   password: string;
   name: string;
-  created_at: Date;
-  updated_at?: Date;
+  created_at: Date | number;
+  updated_at?: Date | number;
   deleted_at?: Date;
 }
 
@@ -13,8 +13,8 @@ const schema = new Schema<IUser>({
   email: { type: String, required: true },
   password: { type: String, required: true },
   name: { type: String, required: true },
-  created_at: { type: Date, required: true },
-  updated_at: { type: Date },
+  created_at: { type: Date, default: Date.now, required: true },
+  updated_at: { type: Date, default: Date.now },
   deleted_at: { type: Date },
 });
 

--- a/src/model/users.model.ts
+++ b/src/model/users.model.ts
@@ -4,19 +4,20 @@ interface IUser {
   email: string;
   password: string;
   name: string;
-  created_at: Date | number;
-  updated_at?: Date | number;
-  deleted_at?: Date;
+  created_at: Date;
+  updated_at?: Date;
+  deleted_at?: Date | null;
 }
 
-const schema = new Schema<IUser>({
-  email: { type: String, required: true },
-  password: { type: String, required: true },
-  name: { type: String, required: true },
-  created_at: { type: Date, default: Date.now },
-  updated_at: { type: Date, default: Date.now },
-  deleted_at: { type: Date },
-});
+const schema = new Schema<IUser>(
+  {
+    email: { type: String, required: true },
+    password: { type: String, required: true },
+    name: { type: String, required: true },
+    deleted_at: { type: Date, default: null },
+  },
+  { timestamps: { createdAt: "created_at", updatedAt: "updated_at" } }
+);
 
 const UserModel = model<IUser>("users", schema);
 

--- a/src/model/users.model.ts
+++ b/src/model/users.model.ts
@@ -13,7 +13,7 @@ const schema = new Schema<IUser>({
   email: { type: String, required: true },
   password: { type: String, required: true },
   name: { type: String, required: true },
-  created_at: { type: Date, default: Date.now, required: true },
+  created_at: { type: Date, default: Date.now },
   updated_at: { type: Date, default: Date.now },
   deleted_at: { type: Date },
 });


### PR DESCRIPTION
Resolves : #15 

## 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [x] 리팩터링

## 작업 개요
- 유저와 게시글 모델의 날짜 필드에 기본값을 추가, 댓글과 대댓글에 날짜 필드 추가

## 상세 내용
- 댓글과 대댓글에 created_at, deleted_at 필드 작성
- 스키마를 작성할 때 timestamps 를 적용해서 자동으로 현재 날짜를 적용하도록 수정

## 집중 요망

