### PR TITLE
fix: 게시글 수정, 삭제 전에 이미 지운 글인지를 확인하는 과정을 추가

### DIFF
--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -43,7 +43,6 @@ export class BoardService {
       const response = await BoardModel.create(createQuery);
       return response;
     } catch (error) {
-      console.log("error");
       throw createError(500, "게시글 작성에 에러가 발생했습니다.");
     }
   }

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -21,11 +21,13 @@ export class BoardService {
   }: ICheckAuthToBoardInput): Promise<ICheckAuthToBoardOutput> {
     try {
       const board = await BoardModel.findOne({ _id: board_id })
-        .select("user_id")
+        .select("user_id deleted_at")
         .lean();
       // console.log("board: ", board);
       if (!board) return { ok: false, error: "일치하는 글이 없습니다." };
-
+      if (Object.prototype.hasOwnProperty.call(board, "deleted_at")) {
+        return { ok: false, error: "이미 삭제한 게시글입니다." };
+      }
       if (board?.user_id.equals(user_id)) {
         return { ok: true };
       } else {


### PR DESCRIPTION
Resolves: #8 #9

## 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [x] 리팩터링

## 작업 개요
- 게시글 수정, 삭제 전에 이미 지운 글인지를 확인하는 과정 추가

## 상세 내용
- 게시글의 deleted_at 이 Date인지 아닌지를 판별하여 확인합니다

## 집중 요망!
